### PR TITLE
Add "You Missed!" to item_data

### DIFF
--- a/Rom.py
+++ b/Rom.py
@@ -499,7 +499,8 @@ item_data: Dict[str, ItemData] = {
     "One Hundred Fifty Coins": ItemData(150, ItemCategory.coin),
     "Frog Coin": ItemData(1, ItemCategory.frog_coin),
     "Flower": ItemData(1, ItemCategory.flower),
-    "Recovery Mushroom": ItemData(0, ItemCategory.recovery)
+    "Recovery Mushroom": ItemData(0, ItemCategory.recovery),
+    "You Missed!": ItemData(0, ItemCategory.coin) # Sends 0 coins as a temporary measure to prevent an SNI Disconnect if "You Missed!" ends up non-local
 }
 
 


### PR DESCRIPTION
This is a temporary fix to an error if a `You Missed!` item ends up in another world, or is given with the `!GetItem` command via the client.

```Text
[FileLog at $TIMESTAMP]: Cheat console: sending "You Missed!" to HikthurRosalina
[SNES at $TIMESTAMP]: An error occurred, see logs for details: 'You Missed!'
[root at $TIMESTAMP]: 'You Missed!'
Traceback (most recent call last):
  File "SNIClient.py", line 662, in game_watcher
  File "$PATHTOARCHIPELAGO\Archipelago\custom_worlds\smrpg.apworld\smrpg\Client.py", line 41, in game_watcher
    await self.received_items_check(ctx)
  File "$PATHTOARCHIPELAGO\Archipelago\custom_worlds\smrpg.apworld\smrpg\Client.py", line 98, in received_items_check
    item_data = Rom.item_data[item_name]
                ~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'You Missed!'
[SNES at $TIMESTAMP]: Lost connection to the snes, type /snes to reconnect
```

Local testing indicates this worked:
![image](https://github.com/user-attachments/assets/8c6d4774-a0a0-43cf-b4c6-7908050eb50d)